### PR TITLE
Fix typo in docs introduction

### DIFF
--- a/src/content/docs/player/overview/getting-started/introduction.mdx
+++ b/src/content/docs/player/overview/getting-started/introduction.mdx
@@ -1,5 +1,5 @@
 ---
-description: Overview of the player library and all of it's features.
+description: Overview of the player library and all of its features.
 slug: player
 ---
 


### PR DESCRIPTION
Hi hi — thanks for all your work on Vidstack! Really appreciate it.

This typo caught my eye since it was at the start of the docs and thought I'd submit a quick fix.

![Screenshot reads: Overview of the player library and all of it's features.](https://github.com/vidstack/site/assets/1007202/6f8d438c-843b-410a-82e4-fba2d13b8c25)

For avoidance of doubt, [a source](https://www.merriam-webster.com/grammar/when-to-use-its-vs-its) for the grammar.
