### PR TITLE
use `isHLSProvider` and `isDASHProvider`instead of manually checking type

### DIFF
--- a/src/snippets/docs/player/api/providers/dash/wc/importing.ts
+++ b/src/snippets/docs/player/api/providers/dash/wc/importing.ts
@@ -1,8 +1,9 @@
 import DASH from 'dashjs';
+import {isDASHProvider} from 'vidstack'
 
 player.addEventListener('provider-change', (event) => {
   const provider = event.detail;
-  if (provider?.type === 'dash') {
+  if (isDASHProvider(provider)) {
     // Static import
     provider.library = DASH;
     // Or, dynamic import

--- a/src/snippets/docs/player/api/providers/hls/wc/importing.ts
+++ b/src/snippets/docs/player/api/providers/hls/wc/importing.ts
@@ -1,8 +1,9 @@
 import HLS from 'hls.js';
+import {isHLSProvider} from 'vidstack'
 
 player.addEventListener('provider-change', (event) => {
   const provider = event.detail;
-  if (provider?.type === 'hls') {
+  if (isHLSProvider(provider)) {
     // Static import
     provider.library = HLS;
     // Or, dynamic import


### PR DESCRIPTION
This provides better narrowing for typescript and prevents a type error when setting `provider.library`.